### PR TITLE
Initial room database

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,6 +12,7 @@
         <entry key="../../../../../layout/compose-model-1645084132505.xml" value="0.41834451901565994" />
         <entry key="../../../../../layout/compose-model-1645107047989.xml" value="0.43847874720357943" />
         <entry key="../../../../../layout/compose-model-1645174275284.xml" value="0.7878787878787878" />
+        <entry key="../../../../../layout/compose-model-1645441323023.xml" value="0.32559121621621623" />
         <entry key="../../../../layout/compose-model-1644928077276.xml" value="0.14611204013377926" />
         <entry key="../../../../layout/compose-model-1644928632733.xml" value="0.2951858108108108" />
         <entry key="../../../../layout/compose-model-1645015855717.xml" value="0.4865771812080537" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,4 +90,10 @@ dependencies {
     implementation 'org.osmdroid:osmdroid-android:6.1.10'
     implementation 'androidx.preference:preference-ktx:1.1.1'
 
+    //  Room related
+    def roomVersion = "2.4.1"
+    implementation "androidx.room:room-runtime:$roomVersion"
+    annotationProcessor "androidx.room:room-compiler:$roomVersion"
+    kapt "androidx.room:room-compiler:$roomVersion"
+    implementation "androidx.room:room-ktx:$roomVersion"
 }

--- a/app/src/main/java/fi/sportionbois/sportion/MainActivity.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/MainActivity.kt
@@ -5,11 +5,13 @@ import android.app.Application
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.R
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ActivityCompat
@@ -19,6 +21,8 @@ import com.google.android.gms.fitness.FitnessOptions
 import com.google.android.gms.fitness.data.DataType
 import fi.sportionbois.sportion.GoogleFit.getFitApiData
 import androidx.preference.PreferenceManager
+import fi.sportionbois.sportion.entities.LocationActivity
+import fi.sportionbois.sportion.entities.User
 import fi.sportionbois.sportion.location.LocationHandler
 import fi.sportionbois.sportion.navigation.BottomNavigationBar
 import fi.sportionbois.sportion.navigation.NavigationGraph
@@ -27,6 +31,7 @@ import fi.sportionbois.sportion.ui.theme.SportionTheme
 import java.time.LocalDate
 import fi.sportionbois.sportion.viewmodels.LocationViewModel
 import fi.sportionbois.sportion.viewmodels.AccelerometerViewModel
+import fi.sportionbois.sportion.viewmodels.UserViewModel
 import org.osmdroid.config.Configuration
 import org.osmdroid.views.MapView
 
@@ -34,8 +39,9 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         private lateinit var locationViewModel: LocationViewModel
+        private lateinit var userViewModel: UserViewModel
     }
-    
+
     @ExperimentalMaterialApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,9 +69,11 @@ class MainActivity : ComponentActivity() {
                 fitnessOptions)
         } else {
             getFitApiData(this, fitnessOptions, startTime, endTime)
-        }
-*/
-        locationViewModel = LocationViewModel(Application())
+        }*/
+
+        locationViewModel = LocationViewModel(application)
+        userViewModel = UserViewModel(application)
+        userViewModel.insert(User("Koistine", "Juha", "Koistinen"))
         ActivityCompat.requestPermissions(
             this,
             arrayOf(android.Manifest.permission.ACCESS_FINE_LOCATION,

--- a/app/src/main/java/fi/sportionbois/sportion/composables/LocationResult.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/composables/LocationResult.kt
@@ -15,15 +15,16 @@ import androidx.compose.ui.unit.dp
 import com.github.mikephil.charting.data.Entry
 import fi.sportionbois.sportion.components.DetailComponent
 import fi.sportionbois.sportion.components.PlotChart
-import fi.sportionbois.sportion.components.RPEBar
 import fi.sportionbois.sportion.viewmodels.LocationViewModel
 import java.util.ArrayList
-import kotlin.math.absoluteValue
 
 @Composable
 fun LocationResult(locationViewModel: LocationViewModel) {
     val value by locationViewModel.travelledDistance.observeAsState()
     val locationData by locationViewModel.locationData.observeAsState()
+    val latestLocationActivityId = locationViewModel.getLatestLocationActivity().observeAsState()
+    val databaseDataPoints by locationViewModel.getDataPointsForId(latestLocationActivityId.value ?: 0).observeAsState()
+
     val lineEntrySpeed = ArrayList<Entry>()
     val lineEntryAltitude = ArrayList<Entry>()
 
@@ -35,7 +36,9 @@ fun LocationResult(locationViewModel: LocationViewModel) {
             .padding(vertical = 32.dp, horizontal = 32.dp)
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().height(300.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(300.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             ShowMap(lat = 1.1, lon = 1.1, address = "")
@@ -46,6 +49,7 @@ fun LocationResult(locationViewModel: LocationViewModel) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
+            //DetailComponent(firstValue = "%.1f".format(databaseData?.totalDistance), secondValue = "distance")
             DetailComponent(firstValue = "%.1f".format(value), secondValue = "distance")
         }
         Column(
@@ -60,6 +64,17 @@ fun LocationResult(locationViewModel: LocationViewModel) {
             PlotChart(lineEntrySpeed, "Description for chart")
             Spacer(modifier = Modifier.padding(16.dp))
             PlotChart(lineEntryAltitude, "Description for chart")
+        }
+        Column() {
+            databaseDataPoints?.forEach {
+                Row {
+                    Text(text = it.lat.toString())
+                    Text(text = it.lon.toString())
+                    Text(text = it.speed.toString())
+                    Text(text = "Distance ${it.totalDistance}")
+                }
+                Spacer(modifier = Modifier.padding(20.dp))
+            }
         }
     }
 }

--- a/app/src/main/java/fi/sportionbois/sportion/composables/StartTracking.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/composables/StartTracking.kt
@@ -26,6 +26,7 @@ import fi.sportionbois.sportion.components.SportTypeButton
 import fi.sportionbois.sportion.location.LocationHandler
 import fi.sportionbois.sportion.viewmodels.LocationViewModel
 import fi.sportionbois.sportion.components.SportTypeCardButton
+import fi.sportionbois.sportion.entities.LocationActivity
 import fi.sportionbois.sportion.viewmodels.AccelerometerViewModel
 
 @ExperimentalMaterialApi
@@ -47,6 +48,7 @@ fun StartTracking(
         ButtonCHViolet(text = "START", onClick = {
             locationHandler.startLocationTracking()
             navController.navigate("TrackingActive")
+            locationViewModel.insert(LocationActivity( "Koistine", 0))
         })
     }
 }

--- a/app/src/main/java/fi/sportionbois/sportion/composables/TrackingActive.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/composables/TrackingActive.kt
@@ -14,6 +14,7 @@ import fi.sportionbois.sportion.components.RPEBar
 import fi.sportionbois.sportion.location.LocationHandler
 import fi.sportionbois.sportion.viewmodels.LocationViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import fi.sportionbois.sportion.entities.LocationActivity
 import fi.sportionbois.sportion.viewmodels.AccelerometerViewModel
 
 @Composable
@@ -25,6 +26,8 @@ fun TrackingActive(
 ) {
     val value by locationViewModel.travelledDistance.observeAsState()
     val acc = accelerometerViewModel.acceleration.observeAsState()
+    val testData = locationViewModel.getLatestLocationActivity().observeAsState()
+    locationViewModel.updateCurrentActivityId(testData.value?.toInt() ?: 0)
     accelerometerViewModel.listen()
     //Log.d("acc", acc.value.toString())
 

--- a/app/src/main/java/fi/sportionbois/sportion/database/ActivityDB.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/database/ActivityDB.kt
@@ -1,0 +1,32 @@
+package fi.sportionbois.sportion.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import fi.sportionbois.sportion.entities.LocationActivity
+import fi.sportionbois.sportion.entities.LocationDataPoint
+import fi.sportionbois.sportion.entities.User
+
+@Database(entities = [(LocationActivity::class), (User::class), (LocationDataPoint::class)], version = 1)
+abstract class ActivityDB : RoomDatabase() {
+    abstract fun locationActivityDao(): LocationActivityDao
+    abstract fun locationDataPointDao(): LocationDataPointDao
+    abstract fun userDao(): UserDao
+
+    companion object {
+        private var sInstance: ActivityDB? = null
+
+        @Synchronized
+        fun get(context: Context): ActivityDB {
+            if (sInstance == null) {
+                sInstance =
+                    Room.databaseBuilder(
+                        context.applicationContext,
+                        ActivityDB::class.java, "activities.db"
+                    ).build()
+            }
+            return sInstance!!
+        }
+    }
+}

--- a/app/src/main/java/fi/sportionbois/sportion/database/LocationActivityDao.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/database/LocationActivityDao.kt
@@ -1,0 +1,21 @@
+package fi.sportionbois.sportion.database
+
+import androidx.lifecycle.LiveData
+import androidx.room.*
+import fi.sportionbois.sportion.entities.LocationActivity
+import fi.sportionbois.sportion.entities.User
+
+@Dao
+interface LocationActivityDao {
+    @Query("SELECT * FROM locationactivity")
+    fun getAll(): LiveData<List<LocationActivity>>
+
+    @Query("SELECT * FROM locationactivity WHERE locationactivity.user = :username")
+    fun getUserActivities(username: String): LiveData<LocationActivity>
+
+    @Query("SELECT activityId FROM locationactivity ORDER BY activityId DESC LIMIT 1")
+    fun getLatestActivityId(): LiveData<Int>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(locationActivity: LocationActivity): Long
+}

--- a/app/src/main/java/fi/sportionbois/sportion/database/LocationDataPointDao.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/database/LocationDataPointDao.kt
@@ -1,0 +1,17 @@
+package fi.sportionbois.sportion.database
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fi.sportionbois.sportion.entities.LocationDataPoint
+
+@Dao
+interface LocationDataPointDao {
+    @Query("SELECT * FROM locationdatapoint WHERE locationdatapoint.activity = :activityId")
+    fun getLocationDataPointsForId(activityId: Int): LiveData<List<LocationDataPoint>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(locationDataPoint: LocationDataPoint): Long
+}

--- a/app/src/main/java/fi/sportionbois/sportion/database/UserDao.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/database/UserDao.kt
@@ -1,0 +1,20 @@
+package fi.sportionbois.sportion.database
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fi.sportionbois.sportion.entities.User
+
+@Dao
+interface UserDao {
+    @Query("SELECT * FROM user")
+    fun getAll(): LiveData<List<User>>
+
+    @Query("SELECT * FROM user WHERE user.username = :username")
+    fun getUserLocationActivities(username: String): LiveData<User>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(user: User): Long
+}

--- a/app/src/main/java/fi/sportionbois/sportion/entities/LocationActivity.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/entities/LocationActivity.kt
@@ -1,0 +1,20 @@
+package fi.sportionbois.sportion.entities
+
+import androidx.room.*
+import androidx.room.ForeignKey.CASCADE
+
+@Entity(
+    foreignKeys = [ForeignKey(
+        entity = User::class,
+        onDelete = CASCADE,
+        parentColumns = ["username"],
+        childColumns = ["user"]
+    )]
+)
+data class LocationActivity(
+    val user: String,
+    @PrimaryKey(autoGenerate = true)
+    val activityId: Int
+) {
+    override fun toString() = "$user activityId $activityId"
+}

--- a/app/src/main/java/fi/sportionbois/sportion/entities/LocationDataPoint.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/entities/LocationDataPoint.kt
@@ -1,0 +1,24 @@
+package fi.sportionbois.sportion.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    foreignKeys = [ForeignKey(
+        entity = LocationActivity::class,
+        onDelete = ForeignKey.CASCADE,
+        parentColumns = ["activityId"],
+        childColumns = ["activity"]
+    )]
+)
+data class LocationDataPoint(
+    var activity: Int,
+    var lat: Float,
+    var lon: Float,
+    var speed: Float,
+    @PrimaryKey
+    var totalDistance: Float
+) {
+    override fun toString() = "$activity activityId"
+}

--- a/app/src/main/java/fi/sportionbois/sportion/entities/User.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/entities/User.kt
@@ -1,0 +1,14 @@
+package fi.sportionbois.sportion.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class User(
+    @PrimaryKey
+    val username: String,
+    val firstname: String,
+    val lastname: String
+) {
+    override fun toString() = "$firstname $lastname ($username)"
+}

--- a/app/src/main/java/fi/sportionbois/sportion/entities/UserLocationActivities.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/entities/UserLocationActivities.kt
@@ -1,0 +1,12 @@
+package fi.sportionbois.sportion.entities
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+class UserLocationActivities {
+    @Embedded
+    var user: User? = null
+
+    @Relation(parentColumn = "uid", entityColumn = "user")
+    var activities: List<UserLocationActivities>? = null
+}

--- a/app/src/main/java/fi/sportionbois/sportion/location/LocationHandler.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/location/LocationHandler.kt
@@ -6,8 +6,10 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Looper
 import android.util.Log
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.core.app.ActivityCompat
 import com.google.android.gms.location.*
+import fi.sportionbois.sportion.entities.LocationDataPoint
 import fi.sportionbois.sportion.viewmodels.LocationViewModel
 
 class LocationHandler(context: Context, locationViewModel: LocationViewModel) {
@@ -40,13 +42,22 @@ class LocationHandler(context: Context, locationViewModel: LocationViewModel) {
                     totalDistance += p0.lastLocation.distanceTo(previousLocation)
                     locationViewModel.updateLocationDistanceTo(totalDistance)
                     locationViewModel.updateLocationData(p0.lastLocation)
+                    locationViewModel.insertLocationDataPoints(
+                        LocationDataPoint(
+                            locationViewModel.currentActivityId.value ?: 0,
+                            p0.lastLocation.latitude.toFloat(),
+                            p0.lastLocation.longitude.toFloat(),
+                            p0.lastLocation.speed.toFloat(),
+                            totalDistance
+                        )
+                    )
                 }
                 previousLocation = p0.lastLocation
                 Log.d("PREVLOC", totalDistance.toString())
                 for (location in p0.locations) {
                     Log.d(
                         "GEOLOCATION",
-                        "new location latitude: ${location.latitude} and longitude: ${location.longitude}"
+                        "new location latitude: ${location.latitude} and longitude: ${location.longitude}, actid ${locationViewModel.currentActivityId.value}"
                     )
                 }
             }

--- a/app/src/main/java/fi/sportionbois/sportion/viewmodels/LocationViewModel.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/viewmodels/LocationViewModel.kt
@@ -3,15 +3,59 @@ package fi.sportionbois.sportion.viewmodels
 import android.app.Application
 import android.location.Location
 import android.util.Log
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import androidx.room.TypeConverter
+import fi.sportionbois.sportion.database.ActivityDB
+import fi.sportionbois.sportion.entities.LocationActivity
+import fi.sportionbois.sportion.entities.LocationDataPoint
+import fi.sportionbois.sportion.entities.User
+import kotlinx.coroutines.launch
+import java.util.*
 
 class LocationViewModel(application: Application) : AndroidViewModel(application) {
     private var _travelledDistance: MutableLiveData<Float> = MutableLiveData(0f)
-    private var _locationData: MutableLiveData<MutableList<Location>> = MutableLiveData(mutableListOf())
     var travelledDistance: LiveData<Float> = _travelledDistance
+
+    private var _locationData: MutableLiveData<MutableList<Location>> =
+        MutableLiveData(mutableListOf())
     var locationData: MutableLiveData<MutableList<Location>> = _locationData
+
+    //  Livedata variable for storing the activityId of current activity. Used for binding
+    //  LocationDataPoint entities to LocationActivity entity
+    private var _currentActivityId: MutableLiveData<Int> = MutableLiveData(0)
+    var currentActivityId: LiveData<Int> = _currentActivityId
+
+    private val activityDB = ActivityDB.get(application)
+
+    //  Returns a list of all the Location Activities
+    fun getAllLocationActivities(username: String): LiveData<List<LocationActivity>> =
+        activityDB.locationActivityDao().getAll()
+
+    //  Sorts all the LocationActivities based on the activityId and returns the last one
+    fun getLatestLocationActivity(): LiveData<Int> =
+        activityDB.locationActivityDao().getLatestActivityId()
+
+    //  Returns LocationDataPoints for the given LocationActivity
+    fun getDataPointsForId(activityId: Int): LiveData<List<LocationDataPoint>> =
+        activityDB.locationDataPointDao().getLocationDataPointsForId(activityId = activityId)
+
+    //  Insert LocationActivity with username and activityId information
+    fun insert(locationActivity: LocationActivity) {
+        viewModelScope.launch {
+            activityDB.locationActivityDao().insert(locationActivity = locationActivity)
+        }
+    }
+
+    //  Insert LocationDataPoints which includes geolocation and speed data from a location
+    fun insertLocationDataPoints(locationDataPoint: LocationDataPoint) {
+        viewModelScope.launch {
+            activityDB.locationDataPointDao().insert(locationDataPoint = locationDataPoint)
+        }
+    }
 
     fun updateLocationDistanceTo(distance: Float) {
         _travelledDistance.value = distance
@@ -19,5 +63,9 @@ class LocationViewModel(application: Application) : AndroidViewModel(application
 
     fun updateLocationData(location: Location) {
         _locationData.value?.add(location)
+    }
+
+    fun updateCurrentActivityId(activityId: Int) {
+        _currentActivityId.value = activityId
     }
 }

--- a/app/src/main/java/fi/sportionbois/sportion/viewmodels/UserViewModel.kt
+++ b/app/src/main/java/fi/sportionbois/sportion/viewmodels/UserViewModel.kt
@@ -1,0 +1,23 @@
+package fi.sportionbois.sportion.viewmodels
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.viewModelScope
+import fi.sportionbois.sportion.database.ActivityDB
+import fi.sportionbois.sportion.entities.User
+import kotlinx.coroutines.launch
+
+class UserViewModel(application: Application) : AndroidViewModel(application) {
+    private val activityDB = ActivityDB.get(application)
+
+    //  For possible future use
+    fun getAll(): LiveData<List<User>> = activityDB.userDao().getAll()
+
+    //  Inserts a user to database
+    fun insert(user: User) {
+        viewModelScope.launch {
+            activityDB.userDao().insert(user = user)
+        }
+    }
+}


### PR DESCRIPTION
Room database base for tracking location activities. 

App can now create an user, LocationActivity entities and LocationDataPoint entities. LocationActivity is created when Start Tracking is pressed and data of the new Activity's ID is passed to LocationHandler via LocationViewModel. This ID is used as foreign key in the LocationDataPoint entities to tie them to the current LocationActivity. 

Tried storing the Location objects to Room, but that didn't turn out well.